### PR TITLE
Fix QuoteForm type usage

### DIFF
--- a/src/components/QuoteForm.tsx
+++ b/src/components/QuoteForm.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { X } from 'lucide-react';
 import './QuoteForm.css';
+import type { FormData } from '../types/types';
 
 interface QuoteFormProps {
   currentStep: number;
-  formData: any;
+  formData: FormData;
   onInputChange: (field: string, value: string) => void;
   onOptionToggle: (option: string) => void;
   onNextStep: () => void;


### PR DESCRIPTION
## Summary
- import FormData type into QuoteForm
- use FormData instead of `any` in QuoteFormProps

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6877c2a56b90832da9bc378569cb1c7a