### PR TITLE
Add analytics tracking to hero compare click

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { initAnalytics, trackPageView, trackQuoteSelected } from './services/analytics';
+import { initAnalytics, trackPageView, trackQuoteSelected, trackEvent } from './services/analytics';
 import Header from './components/Header';
 import HeroSection from './components/HeroSection';
 import Features from './components/Features';
@@ -259,6 +259,7 @@ const App: React.FC = () => {
               <>
                 <HeroSection onCompareClick={() => {
                   console.log('Compare button clicked - setting showQuoteForm to true');
+                  trackEvent('CTA', 'Hero Compare Click');
                   setShowQuoteForm(true);
                   setShowResults(false);
                   setCurrentStep(0);


### PR DESCRIPTION
## Summary
- import `trackEvent` in `App`
- trigger `trackEvent('CTA', 'Hero Compare Click')` before showing the quote form

## Testing
- `npm run lint` *(fails: 5 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688bd7c5e860832d93c9c78aae025955