### PR TITLE
Add date validation to QuoteForm

### DIFF
--- a/src/components/QuoteForm.css
+++ b/src/components/QuoteForm.css
@@ -145,6 +145,17 @@
   min-height: 48px;
 }
 
+.quoteformw-input.error {
+  border-color: #ef4444;
+  background: #fef2f2;
+}
+
+.error-message {
+  color: #ef4444;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
 .quoteformw-input:focus,
 .quoteformw-select:focus {
   border: 1.5px solid #22314A;


### PR DESCRIPTION
## Summary
- validate birthdate and license date in quote form
- display validation messages for invalid dates
- add error styling for date inputs
- prevent moving to the next step until validations succeed

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars in other files)*
- `npm run build` *(fails: TypeScript errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_688bd8a28488832d84f8345207a7e300