### PR TITLE
Add franchise and options filters

### DIFF
--- a/src/components/Results.css
+++ b/src/components/Results.css
@@ -311,4 +311,19 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
-} 
+}
+
+.results-options-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.results-option-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.9rem;
+  color: var(--color-blue-dark);
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -56,10 +56,12 @@ export interface Quote {
     protectionJuridique: boolean;
   }
   
-  export interface Filters {
+export interface Filters {
     insurer: string;
     coverage: string;
     maxPrice: string;
+    deductible: string;
+    options: string[];
   }
 
   // Nouveaux types pour l'espace clients et admin


### PR DESCRIPTION
## Summary
- allow filtering by deductible and option list in results
- compute available option list from quotes
- document new filter types
- style option filters

## Testing
- `npm run lint` *(fails: About.tsx, Assurance.tsx, Login.tsx, Register.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688bdb8e2d04832db924da7d891dba3c