### PR TITLE
Add subscribe analytics event

### DIFF
--- a/src/components/QuoteDownloadModal.tsx
+++ b/src/components/QuoteDownloadModal.tsx
@@ -79,6 +79,7 @@ const QuoteDownloadModal: React.FC<QuoteDownloadModalProps> = ({
           {quote.subscribeUrl && (
             <button
               onClick={() => {
+                trackEvent('Quote', 'Subscribe', quote.insurer);
                 onSubscribe?.(quote.subscribeUrl);
                 onClose();
               }}


### PR DESCRIPTION
## Summary
- track when users click **Souscrire en ligne** by calling `trackEvent` before invoking `onSubscribe`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688be352003c832da060a60dc439c22d