### PR TITLE
Add tooltip icons to QuoteForm

### DIFF
--- a/src/components/QuoteForm.css
+++ b/src/components/QuoteForm.css
@@ -302,6 +302,12 @@
   transition: color 0.3s ease;
 }
 
+.label-with-tooltip {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .quoteformw-input,
 .quoteformw-select {
   width: 100%;

--- a/src/components/QuoteForm.tsx
+++ b/src/components/QuoteForm.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { X } from 'lucide-react';
 import './QuoteForm.css';
+import Tooltip from './Tooltip';
 import { saveQuoteProgress, loadQuoteProgress, clearQuoteProgress } from '../utils/saveQuoteUtils';
 
 import type { FormData as QuoteFormData, OptionsDetaillees } from '../types/types';
@@ -437,7 +438,10 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
                 />
               </div>
               <div>
-                <label className="quoteformw-label">Prix estimé de la vente*</label>
+                <label className="quoteformw-label label-with-tooltip">
+                  <span>Prix estimé de la vente*</span>
+                  <Tooltip message="Valeur vénale: estimation du prix actuel du véhicule." />
+                </label>
                 <input
                   type="number"
                   value={formData.prixVente}
@@ -547,7 +551,10 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
             </div>
             <div className="quoteformw-grid">
               <div>
-                <label className="quoteformw-label">Niveau de franchise souhaité (FCFA)*</label>
+                <label className="quoteformw-label label-with-tooltip">
+                  <span>Niveau de franchise souhaité (FCFA)</span>
+                  <Tooltip message="Part des frais restant à votre charge après un sinistre." />
+                </label>
                 <input
                   type="number"
                   value={formData.niveauFranchise}
@@ -621,7 +628,10 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
             </div>
             <div className="quoteformw-grid">
               <div>
-                <label className="quoteformw-label">Formule d'assurance*</label>
+                <label className="quoteformw-label label-with-tooltip">
+                  <span>Formule d'assurance*</span>
+                  <Tooltip message="Détermine l'étendue de la couverture de votre contrat." />
+                </label>
                 <div className="quoteformw-radio-group">
                   <label><input type="radio" name="formule" value="Tiers Simple" checked={formData.formule === 'Tiers Simple'} onChange={(e) => {
                     handleInputChange(e, 'formule');

--- a/src/components/Tooltip.css
+++ b/src/components/Tooltip.css
@@ -1,0 +1,44 @@
+.tooltip-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.tooltip-icon {
+  color: var(--color-blue-main);
+}
+
+.tooltip-box {
+  visibility: hidden;
+  opacity: 0;
+  position: absolute;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #22314A;
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  white-space: nowrap;
+  z-index: 10;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+}
+
+.tooltip-box::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: #22314A transparent transparent transparent;
+}
+
+.tooltip-wrapper:hover .tooltip-box {
+  visibility: visible;
+  opacity: 1;
+}

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { HelpCircle } from 'lucide-react';
+import './Tooltip.css';
+
+interface TooltipProps {
+  message: string;
+}
+
+const Tooltip: React.FC<TooltipProps> = ({ message }) => (
+  <span className="tooltip-wrapper">
+    <HelpCircle size={16} className="tooltip-icon" />
+    <span className="tooltip-box">{message}</span>
+  </span>
+);
+
+export default Tooltip;


### PR DESCRIPTION
## Summary
- add a reusable `Tooltip` component
- style tooltips
- attach tooltips to key technical fields in `QuoteForm`

## Testing
- `npm run lint`
- `npm run build` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_688c05b9fbf4832dbdebb263a363963a