### PR TITLE
Add sidebar navigation to admin layout

### DIFF
--- a/src/components/Admin.css
+++ b/src/components/Admin.css
@@ -80,36 +80,46 @@
   color: #475569;
 }
 
-.admin-tabs {
-  background: white;
-  padding: 0 32px;
-  border-bottom: 1px solid #e2e8f0;
+.admin-layout {
   display: flex;
-  gap: 0;
+  min-height: calc(100vh - 80px);
 }
 
-.tab-btn {
+.admin-sidebar {
+  background: white;
+  padding: 24px;
+  border-right: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 220px;
+}
+
+.sidebar-btn {
   background: none;
   border: none;
-  padding: 16px 24px;
+  padding: 12px 16px;
   color: #64748b;
   font-weight: 600;
   font-size: 0.95rem;
   cursor: pointer;
+  text-align: left;
   transition: all 0.2s ease;
-  border-bottom: 3px solid transparent;
-  position: relative;
+  border-radius: 6px;
 }
 
-.tab-btn:hover {
-  color: var(--color-blue-main);
+.sidebar-btn:hover {
   background: var(--color-blue-bg);
+  color: var(--color-blue-main);
 }
 
-.tab-btn.active {
-  color: var(--color-blue-main);
-  border-bottom-color: var(--color-blue-main);
+.sidebar-btn.active {
   background: var(--color-blue-bg);
+  color: var(--color-blue-main);
+}
+
+.admin-main {
+  flex: 1;
 }
 
 .admin-content {
@@ -827,15 +837,24 @@ tr:hover {
     justify-content: center;
   }
   
-  .admin-tabs {
+  .admin-layout {
+    flex-direction: column;
+  }
+
+  .admin-sidebar {
+    flex-direction: row;
     padding: 0 16px;
+    border-right: none;
+    border-bottom: 1px solid #e2e8f0;
     overflow-x: auto;
   }
-  
-  .tab-btn {
+
+  .sidebar-btn {
     padding: 12px 16px;
     font-size: 0.9rem;
     white-space: nowrap;
+    flex: 1 1 auto;
+    text-align: center;
   }
   
   .admin-content {

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -447,46 +447,56 @@ const Admin: React.FC<AdminProps> = ({ user, onLogout }) => {
         </div>
       </div>
 
-      <div className="admin-tabs">
-        <button
-          className={`tab-btn ${activeTab === 'overview' ? 'active' : ''}`}
-          onClick={() => setActiveTab('overview')}
-        >
-          Vue d'ensemble
-        </button>
-        <button
-          className={`tab-btn ${activeTab === 'requests' ? 'active' : ''}`}
-          onClick={() => setActiveTab('requests')}
-        >
-          Demandes de devis
-        </button>
-        <button
-          className={`tab-btn ${activeTab === 'users' ? 'active' : ''}`}
-          onClick={() => setActiveTab('users')}
-        >
-          Utilisateurs
-        </button>
-        <button
-          className={`tab-btn ${activeTab === 'insurers' ? 'active' : ''}`}
-          onClick={() => setActiveTab('insurers')}
-        >
-          Assureurs
-        </button>
-        <button
-          className={`tab-btn ${activeTab === 'imports' ? 'active' : ''}`}
-          onClick={() => setActiveTab('imports')}
-        >
-          Imports
-        </button>
-        <button
-          className={`tab-btn ${activeTab === 'settings' ? 'active' : ''}`}
-          onClick={() => setActiveTab('settings')}
-        >
-          Paramètres
-        </button>
-      </div>
+      <div className="admin-layout">
+        <aside className="admin-sidebar">
+          <button
+            className={`sidebar-btn ${
+              activeTab === 'overview' ? 'active' : ''
+            }`}
+            onClick={() => setActiveTab('overview')}
+          >
+            Vue d'ensemble
+          </button>
+          <button
+            className={`sidebar-btn ${
+              activeTab === 'requests' ? 'active' : ''
+            }`}
+            onClick={() => setActiveTab('requests')}
+          >
+            Demandes de devis
+          </button>
+          <button
+            className={`sidebar-btn ${activeTab === 'users' ? 'active' : ''}`}
+            onClick={() => setActiveTab('users')}
+          >
+            Utilisateurs
+          </button>
+          <button
+            className={`sidebar-btn ${
+              activeTab === 'insurers' ? 'active' : ''
+            }`}
+            onClick={() => setActiveTab('insurers')}
+          >
+            Assureurs
+          </button>
+          <button
+            className={`sidebar-btn ${activeTab === 'imports' ? 'active' : ''}`}
+            onClick={() => setActiveTab('imports')}
+          >
+            Imports
+          </button>
+          <button
+            className={`sidebar-btn ${
+              activeTab === 'settings' ? 'active' : ''
+            }`}
+            onClick={() => setActiveTab('settings')}
+          >
+            Paramètres
+          </button>
+        </aside>
 
-      <div className="admin-content">
+        <main className="admin-main">
+          <div className="admin-content">
         {activeTab === 'overview' && stats && (
           <div className="overview-tab">
             <div className="stats-overview">
@@ -812,6 +822,8 @@ const Admin: React.FC<AdminProps> = ({ user, onLogout }) => {
             </div>
           </div>
         )}
+      </div>
+        </main>
       </div>
 
       {/* Modal pour voir les détails d'une demande */}

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -89,36 +89,46 @@
   color: #475569;
 }
 
-.dashboard-tabs {
-  background: white;
-  padding: 0 32px;
-  border-bottom: 1px solid #e2e8f0;
+.dashboard-layout {
   display: flex;
-  gap: 0;
+  min-height: calc(100vh - 80px);
 }
 
-.tab-btn {
+.dashboard-sidebar {
+  background: white;
+  padding: 24px;
+  border-right: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 220px;
+}
+
+.sidebar-btn {
   background: none;
   border: none;
-  padding: 16px 24px;
+  padding: 12px 16px;
   color: #64748b;
   font-weight: 600;
   font-size: 0.95rem;
   cursor: pointer;
+  text-align: left;
   transition: all 0.2s ease;
-  border-bottom: 3px solid transparent;
-  position: relative;
+  border-radius: 6px;
 }
 
-.tab-btn:hover {
-  color: var(--color-blue-main);
+.sidebar-btn:hover {
   background: var(--color-blue-bg);
+  color: var(--color-blue-main);
 }
 
-.tab-btn.active {
-  color: var(--color-blue-main);
-  border-bottom-color: var(--color-blue-main);
+.sidebar-btn.active {
   background: var(--color-blue-bg);
+  color: var(--color-blue-main);
+}
+
+.dashboard-main {
+  flex: 1;
 }
 
 .dashboard-content {
@@ -526,15 +536,24 @@
     justify-content: center;
   }
   
-  .dashboard-tabs {
+  .dashboard-layout {
+    flex-direction: column;
+  }
+
+  .dashboard-sidebar {
+    flex-direction: row;
     padding: 0 16px;
+    border-right: none;
+    border-bottom: 1px solid #e2e8f0;
     overflow-x: auto;
   }
-  
-  .tab-btn {
+
+  .sidebar-btn {
     padding: 12px 16px;
     font-size: 0.9rem;
     white-space: nowrap;
+    flex: 1 1 auto;
+    text-align: center;
   }
   
   .dashboard-content {

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -242,28 +242,30 @@ const Dashboard: React.FC<DashboardProps> = ({ user, onLogout }) => {
         </div>
       </div>
 
-      <div className="dashboard-tabs">
-        <button
-          className={`tab-btn ${activeTab === 'overview' ? 'active' : ''}`}
-          onClick={() => setActiveTab('overview')}
-        >
-          Vue d'ensemble
-        </button>
-        <button
-          className={`tab-btn ${activeTab === 'history' ? 'active' : ''}`}
-          onClick={() => setActiveTab('history')}
-        >
-          Historique
-        </button>
-        <button
-          className={`tab-btn ${activeTab === 'profile' ? 'active' : ''}`}
-          onClick={() => setActiveTab('profile')}
-        >
-          Profil
-        </button>
-      </div>
+      <div className="dashboard-layout">
+        <aside className="dashboard-sidebar">
+          <button
+            className={`sidebar-btn ${activeTab === 'overview' ? 'active' : ''}`}
+            onClick={() => setActiveTab('overview')}
+          >
+            Vue d'ensemble
+          </button>
+          <button
+            className={`sidebar-btn ${activeTab === 'history' ? 'active' : ''}`}
+            onClick={() => setActiveTab('history')}
+          >
+            Historique
+          </button>
+          <button
+            className={`sidebar-btn ${activeTab === 'profile' ? 'active' : ''}`}
+            onClick={() => setActiveTab('profile')}
+          >
+            Profil
+          </button>
+        </aside>
 
-      <div className="dashboard-content">
+        <main className="dashboard-main">
+          <div className="dashboard-content">
         {activeTab === 'overview' && (
           <div className="overview-tab">
             <div className="stats-grid">
@@ -418,6 +420,8 @@ const Dashboard: React.FC<DashboardProps> = ({ user, onLogout }) => {
             </div>
           </div>
         )}
+          </div>
+        </main>
       </div>
 
       {/* Modal de modification du profil */}


### PR DESCRIPTION
## Summary
- restructure admin page with new sidebar layout
- style sidebar and responsive behavior
- add sidebar navigation to client dashboard

## Testing
- `npm run lint`
- `npm run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c2609fc1c832d8849d190332201a6